### PR TITLE
fix: Make params async for Next.js 15 compatibility

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -11,8 +11,9 @@ export async function generateStaticParams() {
   }))
 }
 
-export function generateMetadata({ params }) {
-  let post = getBlogPosts().find((post) => post.slug === params.slug)
+export async function generateMetadata({ params }) {
+  let { slug } = await params
+  let post = getBlogPosts().find((post) => post.slug === slug)
   if (!post) {
     return
   }
@@ -51,8 +52,9 @@ export function generateMetadata({ params }) {
   }
 }
 
-export default function Blog({ params }) {
-  let post = getBlogPosts().find((post) => post.slug === params.slug)
+export default async function Blog({ params }) {
+  let { slug } = await params
+  let post = getBlogPosts().find((post) => post.slug === slug)
 
   if (!post) {
     notFound()

--- a/claude.md
+++ b/claude.md
@@ -1,0 +1,19 @@
+# 개인 블로그 프로젝트 Git 워크플로우 규칙
+
+## 1. Repository
+- **GitHub Repository:** `/tenid/ai-native-blog`
+- **Main Branch:** `main`
+
+## 2. Branching Strategy
+- 모든 기능 개발은 `feature/[이슈번호]-[간단-설명-kebab-case]` 형식의 브랜치에서 진행한다.
+- 이슈 번호가 없는 간단한 수정은 `fix/[간단-설명]` 또는 `chore/[간단-설명]` 브랜치를 사용한다.
+
+## 3. Commit Message Convention
+- 모든 커밋 메시지는 **Conventional Commits** 명세를 따른다.
+- (예: `feat: Add author profile component`, `fix: Correct typo in footer`)
+- 커밋 본문에는 변경 이유를 명확히 서술하고, 관련된 GitHub 이슈를 `Closes #[이슈번호]` 형식으로 반드시 포함한다.
+
+## 4. Pull Request (PR) Process
+- 모든 코드는 `main` 브랜치로 직접 푸시할 수 없으며, 반드시 PR을 통해 코드 리뷰를 받아야 한다.
+- PR 제목은 커밋 메시지와 동일한 형식을 따른다.
+- PR 본문은 `.github/PULL_REQUEST_TEMPLATE.md` 템플릿을 사용한다


### PR DESCRIPTION
## Summary
- `app/blog/[slug]/page.tsx`의 `generateMetadata`와 `Blog` 컴포넌트에서 `params`를 `await`하도록 수정
- Next.js 15에서 동적 라우트의 `params`가 비동기로 변경된 사항에 대응
- 프로젝트 Git 워크플로우 규칙 파일(`claude.md`) 추가

## Test plan
- [ ] `npm run build`로 빌드 성공 확인
- [ ] 블로그 개별 포스트 페이지(`/blog/[slug]`) 정상 렌더링 확인
- [ ] 메타데이터(OG 태그 등)가 올바르게 생성되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)